### PR TITLE
Implement month view swipe navigation

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -44,6 +44,28 @@ function getNextIsoDate(isoDate) {
   return next.toISOString().slice(0, 10)
 }
 
+const currentMonthStart = todayIso.slice(0, 7) + '-01'
+
+/**
+ * Returns ISO date string (YYYY-MM-01) for the first day of the previous month.
+ * Input should be an ISO date string. Typically pass a month-start string.
+ */
+function getPreviousMonthStart(isoDate) {
+  const date = new Date(isoDate)
+  const prev = new Date(Date.UTC(date.getUTCFullYear(), date.getUTCMonth() - 1, 1))
+  return prev.toISOString().slice(0, 10)
+}
+
+/**
+ * Returns ISO date string (YYYY-MM-01) for the first day of the next month.
+ * Input should be an ISO date string. Typically pass a month-start string.
+ */
+function getNextMonthStart(isoDate) {
+  const date = new Date(isoDate)
+  const next = new Date(Date.UTC(date.getUTCFullYear(), date.getUTCMonth() + 1, 1))
+  return next.toISOString().slice(0, 10)
+}
+
 function handleSwipe() {
   if (!isSwiping.value) return
 
@@ -60,9 +82,17 @@ function handleSwipe() {
     return
   }
 
-  // Month View: retain existing left/right behavior to switch views
-  if (direction.value === 'left') currentView.value = currentView.value === 'day' ? 'month' : 'day'
-  if (direction.value === 'right') currentView.value = currentView.value === 'month' ? 'day' : 'month'
+  // Month View: left = previous month; right = next month (not beyond current month)
+  if (currentView.value === 'month') {
+    if (direction.value === 'left') {
+      selectedDate.value = getPreviousMonthStart(monthOfSelected.value)
+    }
+    if (direction.value === 'right') {
+      if (monthOfSelected.value === currentMonthStart) return
+      const nextMonth = getNextMonthStart(monthOfSelected.value)
+      selectedDate.value = nextMonth > currentMonthStart ? currentMonthStart : nextMonth
+    }
+  }
 }
 </script>
 


### PR DESCRIPTION
Implement swipe navigation for Month View to move between months, stopping at the current month when swiping right.

---
<a href="https://cursor.com/background-agent?bcId=bc-3761abf2-db38-4327-a5f7-b2900270135b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-3761abf2-db38-4327-a5f7-b2900270135b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

