### PR TITLE
Investigate and fix chat widget backend error

### DIFF
--- a/src/components/ChatModal.vue
+++ b/src/components/ChatModal.vue
@@ -1,6 +1,7 @@
 <script setup>
 import { ref } from 'vue'
 import { supabase } from '@/lib/supabase'
+import { showErrorToast } from '@/lib/toast'
 
 const emit = defineEmits(['close'])
 const props = defineProps({ isOpen: { type: Boolean, default: false } })
@@ -42,6 +43,7 @@ async function sendMessage() {
 	} catch (err) {
 		messages.value[pendingIndex] = { role: 'assistant', content: 'Sorry, I had trouble answering that.' }
 		errorMessage.value = err?.message || 'Something went wrong'
+		showErrorToast(errorMessage.value)
 	} finally {
 		isSending.value = false
 	}


### PR DESCRIPTION
Add error toast notifications to the chat widget to display backend errors.

---
<a href="https://cursor.com/background-agent?bcId=bc-41a60724-3db4-4a5c-a716-178dc256c082">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-41a60724-3db4-4a5c-a716-178dc256c082">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

