### PR TITLE
Two-step Gemini expense query processing

### DIFF
--- a/netlify/functions/chat.js
+++ b/netlify/functions/chat.js
@@ -24,23 +24,16 @@ exports.handler = async function(event) {
 			global: { headers: { Authorization: `Bearer ${token}` } },
 		})
 
-		const today = new Date()
-		const fromDate = new Date(today.getTime() - 30 * 24 * 60 * 60 * 1000)
-		const fromIso = fromDate.toISOString().slice(0, 10)
+		// Step 1: Ask Gemini to return STRICT JSON describing what to search
+		const plan = await getSearchPlanFromGemini(apiKey, question)
 
-		const { data: expenses, error } = await supabase
-			.from('expenses')
-			.select('item,cost,date')
-			.gte('date', fromIso)
-			.order('date', { ascending: false })
-			.limit(300)
+		// Step 2: Query the user's expenses using the plan (falls back if needed)
+		const { data: expenses, error: sbError } = await queryExpensesByPlan(supabase, plan)
+		if (sbError) return jsonRes(500, { error: sbError.message })
 
-		if (error) return jsonRes(500, { error: error.message })
-
-		const context = buildContext(expenses || [])
-		const prompt = buildPrompt(question, context)
-
-		const aiResponse = await callGemini(apiKey, prompt)
+		// Step 3: Ask Gemini to answer using the original question + fetched expenses
+		const answerPrompt = buildAnswerPrompt(question, expenses || [])
+		const aiResponse = await callGemini(apiKey, answerPrompt, { temperature: 0.2, maxOutputTokens: 640 })
 		if (!aiResponse.ok) return jsonRes(500, { error: aiResponse.error || 'AI request failed' })
 
 		return jsonRes(200, { answer: aiResponse.text })
@@ -58,61 +51,132 @@ function jsonRes(statusCode, obj) {
 }
 
 /**
- * Creates compact aggregates to keep token usage low.
+ * Calls Gemini to obtain a strict JSON search plan for expense retrieval.
+ * Returns a plain object with optional keys: { items?: string[], dateRange?: { from: string, to: string }, dates?: string[] }
  */
-function buildContext(expenses) {
-	const totalsByItem = new Map()
-	const totalsByDate = new Map()
-	let grandTotal = 0
+async function getSearchPlanFromGemini(apiKey, question) {
+	const system = [
+		'You are a query planner for a personal expense tracker.',
+		'Return ONLY valid JSON. No prose. No code fences. No trailing commas.',
+		'Match this schema exactly and omit unknown keys:',
+		'{"items": string[] optional, "dateRange": {"from": "YYYY-MM-DD", "to": "YYYY-MM-DD"} optional, "dates": string[] optional}',
+		'Rules:',
+		'- If user mentions items (e.g., bread, taxi) include them in items as lowercase words.',
+		'- If user mentions a specific day, put it in dates as YYYY-MM-DD.',
+		'- If user mentions a range like "last week", compute a reasonable recent range within the past 90 days.',
+		'- If nothing is specified, set dateRange to the last 30 days.',
+	].join('\n')
 
-	for (const e of expenses) {
-		const itemKey = e.item
-		const prevItem = totalsByItem.get(itemKey) || 0
-		totalsByItem.set(itemKey, prevItem + Number(e.cost))
-
-		const dateKey = e.date
-		const prevDate = totalsByDate.get(dateKey) || 0
-		totalsByDate.set(dateKey, prevDate + Number(e.cost))
-
-		grandTotal += Number(e.cost)
-	}
-
-	const topItems = Array.from(totalsByItem.entries())
-		.sort((a, b) => b[1] - a[1])
-		.slice(0, 8)
-		.map(([item, sum]) => ({ item, sum: round2(sum) }))
-
-	const daily = Array.from(totalsByDate.entries())
-		.sort((a, b) => (a[0] < b[0] ? -1 : 1))
-		.map(([date, sum]) => ({ date, sum: round2(sum) }))
-
-	return {
-		windowDays: 30,
-		grandTotal: round2(grandTotal),
-		topItems,
-		daily,
-	}
-}
-
-function round2(n) {
-	return Math.round((Number(n) + Number.EPSILON) * 100) / 100
-}
-
-function buildPrompt(question, context) {
-	return [
-		"You are an assistant for a personal expense tracker. Answer the user's question using ONLY the provided data.",
-		'Amounts are in Gambian Dalasi and should be formatted with the D prefix (e.g., D123.45).',
-		'If the data is insufficient to answer confidently, say so briefly.',
+	const prompt = [
+		system,
 		'',
-		'Context JSON (last 30 days):',
-		JSON.stringify(context),
+		'User question:',
+		question,
+		'',
+		'Respond with ONLY the JSON object.'
+	].join('\n')
+
+	const res = await callGemini(apiKey, prompt, { temperature: 0, maxOutputTokens: 256 })
+	if (!res.ok) return getDefaultPlan()
+
+	const text = (res.text || '').trim()
+	try {
+		const parsed = JSON.parse(text)
+		return sanitizePlan(parsed)
+	} catch (_) {
+		return getDefaultPlan()
+	}
+}
+
+function getDefaultPlan() {
+	const today = new Date()
+	const from = new Date(today.getTime() - 30 * 24 * 60 * 60 * 1000)
+	return { dateRange: { from: toISO(from), to: toISO(today) } }
+}
+
+function sanitizePlan(plan) {
+	const out = {}
+	if (Array.isArray(plan.items)) {
+		out.items = plan.items
+			.map(x => String(x || '').trim())
+			.filter(Boolean)
+	}
+	if (plan.dateRange && typeof plan.dateRange === 'object') {
+		const from = String(plan.dateRange.from || '').slice(0, 10)
+		const to = String(plan.dateRange.to || '').slice(0, 10)
+		if (isISODate(from) && isISODate(to)) out.dateRange = { from, to }
+	}
+	if (Array.isArray(plan.dates)) {
+		const dates = plan.dates
+			.map(x => String(x || '').slice(0, 10))
+			.filter(isISODate)
+		if (dates.length) out.dates = dates
+	}
+	// Ensure we always have at least a default range
+	if (!out.dateRange && !out.dates) return getDefaultPlan()
+	return out
+}
+
+function isISODate(s) {
+	return /^\d{4}-\d{2}-\d{2}$/.test(s)
+}
+
+function toISO(d) {
+	return new Date(Date.UTC(d.getUTCFullYear?.() ?? d.getFullYear(), (d.getUTCMonth?.() ?? d.getMonth()), (d.getUTCDate?.() ?? d.getDate()))).toISOString().slice(0, 10)
+}
+
+/**
+ * Builds and runs a Supabase query based on the search plan.
+ * Selects item,cost,date for the authenticated user (via RLS) and returns { data, error }.
+ */
+async function queryExpensesByPlan(supabase, plan) {
+	let query = supabase
+		.from('expenses')
+		.select('item,cost,date')
+		.order('date', { ascending: false })
+		.limit(500)
+
+	// Date filters
+	if (plan?.dateRange) {
+		query = query.gte('date', plan.dateRange.from).lte('date', plan.dateRange.to)
+	} else if (plan?.dates?.length) {
+		query = query.in('date', plan.dates)
+	}
+
+	// Item filters (OR across items, ilike each)
+	if (plan?.items?.length) {
+		const ors = plan.items
+			.map(term => `item.ilike.%${escapeForIlike(term)}%`)
+			.join(',')
+		if (ors) query = query.or(ors)
+	}
+
+	return await query
+}
+
+function escapeForIlike(s) {
+	return String(s || '')
+		.replace(/%/g, '')
+		.replace(/,/g, ' ')
+}
+
+/**
+ * Builds the second-step prompt to answer naturally using fetched expenses.
+ */
+function buildAnswerPrompt(question, expenses) {
+	return [
+		'You are an assistant for a personal expense tracker. Answer the user naturally using ONLY the provided expenses JSON.',
+		'Amounts are in Gambian Dalasi; format like D123.45. If data is insufficient, say so briefly.',
+		'',
+		'Expenses JSON:',
+		JSON.stringify({ expenses }),
 		'',
 		'User question:',
 		question,
 	].join('\n')
 }
 
-async function callGemini(apiKey, prompt) {
+async function callGemini(apiKey, prompt, config) {
 	const url = `https://generativelanguage.googleapis.com/v1beta/models/gemini-1.5-flash:generateContent?key=${encodeURIComponent(apiKey)}`
 	const res = await fetch(url, {
 		method: 'POST',
@@ -121,7 +185,7 @@ async function callGemini(apiKey, prompt) {
 			contents: [
 				{ role: 'user', parts: [{ text: prompt }] },
 			],
-			generationConfig: { temperature: 0.2, maxOutputTokens: 512 },
+			generationConfig: { temperature: config?.temperature ?? 0.2, maxOutputTokens: config?.maxOutputTokens ?? 512 },
 		}),
 	})
 


### PR DESCRIPTION
Implement a two-step Gemini chat flow to first extract search parameters for expense queries and then answer naturally using the fetched data.

---
<a href="https://cursor.com/background-agent?bcId=bc-e9bd2832-890a-4403-9445-d0b1e78989e3">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-e9bd2832-890a-4403-9445-d0b1e78989e3">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

