### PR TITLE
Adjust modal position for keyboard on mobile

### DIFF
--- a/src/components/AddExpenseModal.vue
+++ b/src/components/AddExpenseModal.vue
@@ -1,6 +1,8 @@
 <script setup>
-import { ref } from 'vue'
+import { ref, computed } from 'vue'
 import AutocompleteInput from './AutocompleteInput.vue'
+import { useKeyboardBottomOffset } from '@/lib/useKeyboardBottomOffset'
+import { useBodyScrollLock } from '@/lib/useBodyScrollLock'
 
 const emit = defineEmits(['close', 'save'])
 const props = defineProps({
@@ -11,6 +13,10 @@ const props = defineProps({
 const item = ref('')
 const cost = ref('')
 const suggestions = ['Bread', 'Milk', 'Coffee', 'Groceries', 'Taxi', 'Dinner', 'Snacks']
+
+const { sheetStyle } = useKeyboardBottomOffset()
+const isOpenRef = computed(() => props.isOpen)
+useBodyScrollLock(isOpenRef)
 
 function handleSave() {
   const parsed = Number.parseFloat(cost.value)
@@ -23,7 +29,7 @@ function handleSave() {
 
 <template>
   <div v-if="isOpen" class="fixed inset-0 z-20 flex items-end sm:items-center justify-center bg-black/30">
-    <div class="w-full sm:max-w-md bg-white dark:bg-gray-800 rounded-t-2xl sm:rounded-2xl p-4 sm:p-6 shadow-xl">
+    <div class="w-full sm:max-w-md bg-white dark:bg-gray-800 rounded-t-2xl sm:rounded-2xl p-4 sm:p-6 shadow-xl" :style="sheetStyle">
       <div class="flex items-center justify-between mb-3">
         <h2 class="text-lg font-semibold">Add Expense</h2>
         <button class="text-gray-500 hover:text-gray-700" @click="$emit('close')">✕</button>

--- a/src/components/ChatModal.vue
+++ b/src/components/ChatModal.vue
@@ -2,6 +2,8 @@
 import { ref } from 'vue'
 import { supabase } from '@/lib/supabase'
 import { showErrorToast } from '@/lib/toast'
+import { useKeyboardBottomOffset } from '@/lib/useKeyboardBottomOffset'
+import { useBodyScrollLock } from '@/lib/useBodyScrollLock'
 
 const emit = defineEmits(['close', 'added'])
 const props = defineProps({ isOpen: { type: Boolean, default: false } })
@@ -10,6 +12,8 @@ const messages = ref([{ role: 'assistant', content: 'Ask me about your spend.' }
 const input = ref('')
 const isSending = ref(false)
 const errorMessage = ref('')
+const { sheetStyle } = useKeyboardBottomOffset()
+useBodyScrollLock(() => props.isOpen)
 
 async function sendMessage() {
 	const q = input.value.trim()
@@ -67,7 +71,7 @@ async function sendMessage() {
 
 <template>
   <div v-if="isOpen" class="fixed inset-0 z-30 flex items-end sm:items-center justify-center bg-black/30">
-    <div class="w-full sm:max-w-md bg-white dark:bg-gray-800 rounded-t-2xl sm:rounded-2xl p-4 sm:p-6 shadow-xl">
+    <div class="w-full sm:max-w-md bg-white dark:bg-gray-800 rounded-t-2xl sm:rounded-2xl p-4 sm:p-6 shadow-xl" :style="sheetStyle">
       <div class="flex items-center justify-between mb-3">
         <h2 class="text-lg font-semibold">Chat</h2>
         <button class="text-gray-500 hover:text-gray-700" @click="$emit('close')">✕</button>

--- a/src/components/EditExpenseModal.vue
+++ b/src/components/EditExpenseModal.vue
@@ -1,5 +1,7 @@
 <script setup>
 import { ref, watch, computed } from 'vue'
+import { useKeyboardBottomOffset } from '@/lib/useKeyboardBottomOffset'
+import { useBodyScrollLock } from '@/lib/useBodyScrollLock'
 
 const emit = defineEmits(['close', 'save', 'delete'])
 const props = defineProps({
@@ -20,6 +22,9 @@ watch(() => props.expense, (e) => {
 
 const isValid = computed(() => !!item.value && !Number.isNaN(Number.parseFloat(cost.value)) && /^\d{4}-\d{2}-\d{2}$/.test(date.value))
 
+const { sheetStyle } = useKeyboardBottomOffset()
+useBodyScrollLock(() => props.isOpen)
+
 function handleSave() {
   const parsedCost = Number.parseFloat(cost.value)
   if (!isValid.value) return
@@ -33,7 +38,7 @@ function handleDelete() {
 
 <template>
   <div v-if="isOpen" class="fixed inset-0 z-20 flex items-end sm:items-center justify-center bg-black/30">
-    <div class="w-full sm:max-w-md bg-white dark:bg-gray-800 rounded-t-2xl sm:rounded-2xl p-4 sm:p-6 shadow-xl">
+    <div class="w-full sm:max-w-md bg-white dark:bg-gray-800 rounded-t-2xl sm:rounded-2xl p-4 sm:p-6 shadow-xl" :style="sheetStyle">
       <div class="flex items-center justify-between mb-3">
         <h2 class="text-lg font-semibold">Edit Expense</h2>
         <button class="text-gray-500 hover:text-gray-700" @click="$emit('close')">✕</button>

--- a/src/lib/useBodyScrollLock.js
+++ b/src/lib/useBodyScrollLock.js
@@ -1,0 +1,52 @@
+import { watch, unref, onBeforeUnmount } from 'vue'
+
+/**
+ * Locks body scroll when `active` is truthy. Preserves prior inline styles.
+ * Accepts a Ref or getter returning a boolean.
+ */
+export function useBodyScrollLock(active) {
+  const previous = {
+    overflow: '',
+    position: '',
+    top: '',
+    left: '',
+    right: '',
+    width: '',
+  }
+  let scrollY = 0
+
+  function lock() {
+    if (document.body.style.overflow === 'hidden') return
+    previous.overflow = document.body.style.overflow
+    previous.position = document.body.style.position
+    previous.top = document.body.style.top
+    previous.left = document.body.style.left
+    previous.right = document.body.style.right
+    previous.width = document.body.style.width
+
+    scrollY = window.scrollY || window.pageYOffset || 0
+    document.body.style.overflow = 'hidden'
+    document.body.style.position = 'fixed'
+    document.body.style.top = `-${scrollY}px`
+    document.body.style.left = '0'
+    document.body.style.right = '0'
+    document.body.style.width = '100%'
+  }
+
+  function unlock() {
+    document.body.style.overflow = previous.overflow
+    document.body.style.position = previous.position
+    document.body.style.top = previous.top
+    document.body.style.left = previous.left
+    document.body.style.right = previous.right
+    document.body.style.width = previous.width
+    window.scrollTo(0, scrollY)
+  }
+
+  watch(() => Boolean(unref(active)), (enabled) => {
+    if (enabled) lock(); else unlock()
+  }, { immediate: true })
+
+  onBeforeUnmount(() => unlock())
+}
+

--- a/src/lib/useKeyboardBottomOffset.js
+++ b/src/lib/useKeyboardBottomOffset.js
@@ -1,0 +1,86 @@
+import { ref, computed, onMounted, onBeforeUnmount } from 'vue'
+
+/**
+ * Tracks on-screen keyboard presence on mobile and computes a bottom offset
+ * so bottom sheets can sit above the keyboard. Uses VisualViewport when available.
+ *
+ * Returns reactive `keyboardOffset` (pixels), `isKeyboardOpen`, and a
+ * `sheetStyle` computed style object suitable for binding to a bottom sheet
+ * container (adds marginBottom, maxHeight, and paddingBottom).
+ */
+export function useKeyboardBottomOffset() {
+  const keyboardOffset = ref(0)
+  const isKeyboardOpen = ref(false)
+  const isMobile = ref(false)
+
+  function updateIsMobile() {
+    try {
+      isMobile.value = window.matchMedia && window.matchMedia('(max-width: 639px)').matches
+    } catch (_) {
+      isMobile.value = window.innerWidth < 640
+    }
+  }
+
+  function computeOffset() {
+    if (!isMobile.value) {
+      keyboardOffset.value = 0
+      isKeyboardOpen.value = false
+      return
+    }
+    const vv = window.visualViewport
+    if (vv && typeof vv.height === 'number') {
+      const bottomInset = Math.max(0, (window.innerHeight - (vv.height + vv.offsetTop)))
+      keyboardOffset.value = bottomInset
+      isKeyboardOpen.value = bottomInset > 0
+      return
+    }
+    // Fallback: no VisualViewport; leave as zero
+    keyboardOffset.value = 0
+    isKeyboardOpen.value = false
+  }
+
+  const sheetStyle = computed(() => {
+    if (!isMobile.value) return {}
+    const offset = keyboardOffset.value
+    // Add a small breathing space (16px) from top when fully expanded
+    const topGapPx = 16
+    return {
+      marginBottom: offset ? `${offset}px` : '',
+      maxHeight: `calc(100dvh - ${offset}px - ${topGapPx}px)`,
+      paddingBottom: `calc(env(safe-area-inset-bottom, 0px) + ${offset}px)`,
+      overflowY: 'auto',
+      WebkitOverflowScrolling: 'touch',
+    }
+  })
+
+  function onViewportChange() {
+    computeOffset()
+  }
+
+  onMounted(() => {
+    updateIsMobile()
+    computeOffset()
+    window.addEventListener('resize', updateIsMobile, { passive: true })
+    const vv = window.visualViewport
+    if (vv) {
+      vv.addEventListener('resize', onViewportChange, { passive: true })
+      vv.addEventListener('scroll', onViewportChange, { passive: true })
+    } else {
+      window.addEventListener('resize', onViewportChange, { passive: true })
+    }
+  })
+
+  onBeforeUnmount(() => {
+    window.removeEventListener('resize', updateIsMobile)
+    const vv = window.visualViewport
+    if (vv) {
+      vv.removeEventListener('resize', onViewportChange)
+      vv.removeEventListener('scroll', onViewportChange)
+    } else {
+      window.removeEventListener('resize', onViewportChange)
+    }
+  })
+
+  return { keyboardOffset, isKeyboardOpen, sheetStyle }
+}
+


### PR DESCRIPTION
Implement mobile keyboard-aware bottom sheet behavior for modals to prevent inputs from being obscured by the on-screen keyboard, and lock background scroll while modals are open.

---
<a href="https://cursor.com/background-agent?bcId=bc-d33eb59c-221d-4fef-ae87-f57d88dce816">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-d33eb59c-221d-4fef-ae87-f57d88dce816">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

